### PR TITLE
feature(cors): permitir frontend en http://localhost:3000

### DIFF
--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -5,6 +5,15 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // 👇 CORS: permitir peticiones del front (otro repo/puerto)
+  app.enableCors({
+    origin: 'http://localhost:3000',
+    credentials: true,
+    methods: ['GET','HEAD','PUT','PATCH','POST','DELETE','OPTIONS'],
+    allowedHeaders: ['Content-Type','Authorization'],
+  });
+
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -21,7 +30,6 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-
   SwaggerModule.setup('api', app, document);
 
   await app.listen(process.env.PORT ?? 3001);


### PR DESCRIPTION
Se habilita CORS para permitir peticiones desde el frontend en http://localhost:3000.

Modificación realizada únicamente en back/src/main.ts.

Configuración incluye:
origin específico para el front local.
credentials habilitados.
Métodos y encabezados comunes permitidos.

Impacto
No afecta la lógica de negocio ni rutas existentes.
Mejora la integración local entre frontend y backend.

Motivo
Permitir que el frontend, alojado en otro repositorio y ejecutándose en un puerto distinto, pueda comunicarse sin errores de CORS con el backend.

